### PR TITLE
Update zkpass client to v1.0.0-alpha.1

### DIFF
--- a/typescript/node-js/cli/.npmrc
+++ b/typescript/node-js/cli/.npmrc
@@ -1,1 +1,1 @@
-@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/
+@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/

--- a/typescript/node-js/cli/package-lock.json
+++ b/typescript/node-js/cli/package-lock.json
@@ -8,7 +8,7 @@
       "name": "typescript-cli",
       "version": "0.1.0",
       "dependencies": {
-        "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+        "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -17,14 +17,14 @@
       }
     },
     "node_modules/@didpass/zkpass-client-ts": {
-      "version": "0.3.0-rc.1",
-      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-0.3.0-rc.1.tgz",
-      "integrity": "sha512-mQN87Thcxnqt6xJcj5JHWzBW73tC2oHfa6EppkS0vMzJku1ULSbEj9FHyW/Yi0rc1mrfdwGsRiKcexfBc0Tjzw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-K12+XDqKBk06OcP0PuV6Qm9sZGC4fGy4jMeUHrPmKRKnk0+woDJHJBKHr2WpsMmfJSEMDOV68y2xmkmbjrIz7w==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ffi-napi": "^4.0.3",
-        "jose": "^4.15.4",
+        "jose": "^4.15.5",
         "patch-package": "^8.0.0",
         "ref-napi": "^3.0.3",
         "ref-struct-napi": "^1.1.1"

--- a/typescript/node-js/cli/package.json
+++ b/typescript/node-js/cli/package.json
@@ -13,7 +13,7 @@
     "demo-jane": "npm run build && node build/index.js ./test/data/jane-blood-test-result.json ./test/data/employee-onboarding-dvr.json"
   },
   "dependencies": {
-    "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+    "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/typescript/node-js/cli/src/utils/constants.ts
+++ b/typescript/node-js/cli/src/utils/constants.ts
@@ -7,7 +7,7 @@
  *   NaufalFakhri (naufal.f.muhammad@gdplabs.id)
  * Created Date: November 29th 2023
  * -----
- * Last Modified: March 14th 2024
+ * Last Modified: April 3rd 2024
  * Modified By: handrianalandi (handrian.alandi@gdplabs.id)
  * -----
  * Reviewers:
@@ -22,7 +22,7 @@
 import { ZkPassApiKey } from "@didpass/zkpass-client-ts";
 
 // Holder constants
-export const ZKPASS_SERVICE_URL: string = "https://playground-zkpass.ssi.id";
+export const ZKPASS_SERVICE_URL: string = "https://staging-zkpass.ssi.id";
 
 // Issuer constants
 export const ISSUER_PRIVKEY: string =
@@ -47,7 +47,7 @@ export const VERIFIER_JKU: string =
 export const EXPECTED_DVR_TTL: number = 600;
 
 // API Keys
-export const KEY = "5ecb2229-ddee-460e-b598-a0001c10fff1";
-export const SECRET = "074a53a8-a252-45de-a9d5-0961a6362df6";
+export const KEY = "e7fd7ec9-33b2-4f33-a383-c2f1d151a7c2";
+export const SECRET = "6a79ffa2-5fe8-4764-8edf-0ebc5dbcccf9";
 export const API_KEY: ZkPassApiKey = new ZkPassApiKey(KEY, SECRET);
 export const ZKPASS_ZKVM = "r0";

--- a/typescript/node-js/client/.npmrc
+++ b/typescript/node-js/client/.npmrc
@@ -1,1 +1,1 @@
-@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/
+@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/

--- a/typescript/node-js/client/package-lock.json
+++ b/typescript/node-js/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
-        "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+        "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.15",
@@ -119,14 +119,14 @@
       }
     },
     "node_modules/@didpass/zkpass-client-ts": {
-      "version": "0.3.0-rc.1",
-      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-0.3.0-rc.1.tgz",
-      "integrity": "sha512-mQN87Thcxnqt6xJcj5JHWzBW73tC2oHfa6EppkS0vMzJku1ULSbEj9FHyW/Yi0rc1mrfdwGsRiKcexfBc0Tjzw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-K12+XDqKBk06OcP0PuV6Qm9sZGC4fGy4jMeUHrPmKRKnk0+woDJHJBKHr2WpsMmfJSEMDOV68y2xmkmbjrIz7w==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ffi-napi": "^4.0.3",
-        "jose": "^4.15.4",
+        "jose": "^4.15.5",
         "patch-package": "^8.0.0",
         "ref-napi": "^3.0.3",
         "ref-struct-napi": "^1.1.1"
@@ -1950,9 +1950,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
-      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/typescript/node-js/client/package.json
+++ b/typescript/node-js/client/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+    "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.15",

--- a/typescript/node-js/client/src/utils/constants.ts
+++ b/typescript/node-js/client/src/utils/constants.ts
@@ -5,7 +5,7 @@
  *   NaufalFakhri (naufal.f.muhammad@gdplabs.id)
  * Created at: December 15th 2023
  * -----
- * Last Modified: March 14th 2024
+ * Last Modified: April 3rd 2024
  * Modified By: handrianalandi (handrian.alandi@gdplabs.id)
  * -----
  * Reviewers:
@@ -20,8 +20,8 @@ export const MYNAMASTE_URL = "http://localhost:3000";
 export const ISSUER_URL = "http://localhost:3001/issuer";
 export const VERIFIER_URL = "http://localhost:3001/verifier";
 
-export const API_KEY = "5ecb2229-ddee-460e-b598-a0001c10fff1";
-export const API_SECRET = "074a53a8-a252-45de-a9d5-0961a6362df6";
-export const ZKPASS_SERVICE_URL = "https://playground-zkpass.ssi.id";
+export const API_KEY = "e7fd7ec9-33b2-4f33-a383-c2f1d151a7c2";
+export const API_SECRET = "6a79ffa2-5fe8-4764-8edf-0ebc5dbcccf9";
+export const ZKPASS_SERVICE_URL = "https://staging-zkpass.ssi.id";
 
 export const ZKPASS_ZKVM = "r0";

--- a/typescript/node-js/issuer-verifier/.npmrc
+++ b/typescript/node-js/issuer-verifier/.npmrc
@@ -1,1 +1,1 @@
-@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/
+@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/

--- a/typescript/node-js/issuer-verifier/package-lock.json
+++ b/typescript/node-js/issuer-verifier/package-lock.json
@@ -8,7 +8,7 @@
       "name": "issuer-verifier",
       "version": "0.1.0",
       "dependencies": {
-        "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+        "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
         "jose": "^4.15.4",
         "next": "13.5.6",
         "react": "^18",
@@ -40,14 +40,14 @@
       }
     },
     "node_modules/@didpass/zkpass-client-ts": {
-      "version": "0.3.0-rc.1",
-      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-0.3.0-rc.1.tgz",
-      "integrity": "sha512-mQN87Thcxnqt6xJcj5JHWzBW73tC2oHfa6EppkS0vMzJku1ULSbEj9FHyW/Yi0rc1mrfdwGsRiKcexfBc0Tjzw==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/@didpass/zkpass-client-ts/-/@didpass/zkpass-client-ts-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-K12+XDqKBk06OcP0PuV6Qm9sZGC4fGy4jMeUHrPmKRKnk0+woDJHJBKHr2WpsMmfJSEMDOV68y2xmkmbjrIz7w==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ffi-napi": "^4.0.3",
-        "jose": "^4.15.4",
+        "jose": "^4.15.5",
         "patch-package": "^8.0.0",
         "ref-napi": "^3.0.3",
         "ref-struct-napi": "^1.1.1"
@@ -1249,9 +1249,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
-      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/typescript/node-js/issuer-verifier/package.json
+++ b/typescript/node-js/issuer-verifier/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@didpass/zkpass-client-ts": "^0.3.0-rc.1",
+    "@didpass/zkpass-client-ts": "^1.0.0-alpha.1",
     "jose": "^4.15.4",
     "next": "13.5.6",
     "react": "^18",

--- a/typescript/node-js/issuer-verifier/src/utils/constants.ts
+++ b/typescript/node-js/issuer-verifier/src/utils/constants.ts
@@ -5,7 +5,7 @@
  *   NaufalFakhri (naufal.f.muhammad@gdplabs.id)
  * Created at: December 15th 2023
  * -----
- * Last Modified: March 14th 2024
+ * Last Modified: April 3rd 2024
  * Modified By: handrianalandi (handrian.alandi@gdplabs.id)
  * -----
  * Reviewers:
@@ -39,8 +39,8 @@ export const ISSUER_JWKS_URL =
   "https://raw.githubusercontent.com/gl-zkPass/zkpass-sdk/main/docs/zkpass/sample-jwks/issuer-key.json";
 export const ISSUER_JWKS_KID = "k-1";
 
-export const API_KEY = "5ecb2229-ddee-460e-b598-a0001c10fff1";
-export const API_SECRET = "074a53a8-a252-45de-a9d5-0961a6362df6";
-export const ZKPASS_SERVICE_URL = "https://playground-zkpass.ssi.id";
+export const API_KEY = "e7fd7ec9-33b2-4f33-a383-c2f1d151a7c2";
+export const API_SECRET = "6a79ffa2-5fe8-4764-8edf-0ebc5dbcccf9";
+export const ZKPASS_SERVICE_URL = "https://staging-zkpass.ssi.id";
 
 export const ZKPASS_ZKVM = "r0";

--- a/typescript/react-native/wallet/.npmrc
+++ b/typescript/react-native/wallet/.npmrc
@@ -1,1 +1,1 @@
-@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/
+@didpass:registry=https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/

--- a/typescript/react-native/wallet/package-lock.json
+++ b/typescript/react-native/wallet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@didpass/zkpass-client-react-native": "^0.3.0-rc.1",
+        "@didpass/zkpass-client-react-native": "^1.0.0-alpha.1",
         "@react-native-clipboard/clipboard": "^1.12.1",
         "@tradle/react-native-http": "^2.0.1",
         "events": "^1.1.1",
@@ -2038,9 +2038,9 @@
       "dev": true
     },
     "node_modules/@didpass/zkpass-client-react-native": {
-      "version": "0.3.0-rc.1",
-      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm-public/@didpass/zkpass-client-react-native/-/@didpass/zkpass-client-react-native-0.3.0-rc.1.tgz",
-      "integrity": "sha512-FCMs92RY66kr1OzQzQntxYHFUGGQeBQYZgHp4Xo6i6pzX77tLcL7NwLglsac6++0pSA7A/B3DMh9iL4HkTcPlQ==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://us-west1-npm.pkg.dev/gdp-labs/gdplabs-npm/@didpass/zkpass-client-react-native/-/@didpass/zkpass-client-react-native-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-Mt+VQo6O0biID2SJaOoorcrtEu3yf/1aXhZKfl/wz79V4NNX9pFb7Mt7lid+1CFX4/Dcoj/9VyQVnr3uyu0IUw==",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/typescript/react-native/wallet/package.json
+++ b/typescript/react-native/wallet/package.json
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@didpass/zkpass-client-react-native": "^0.3.0-rc.1",
+    "@didpass/zkpass-client-react-native": "^1.0.0-alpha.1",
     "@react-native-clipboard/clipboard": "^1.12.1",
     "@tradle/react-native-http": "^2.0.1",
     "events": "^1.1.1",

--- a/typescript/react-native/wallet/src/constants.ts
+++ b/typescript/react-native/wallet/src/constants.ts
@@ -6,11 +6,11 @@
  *   LawrencePatrickSianto (lawrence.p.sianto@gdplabs.id)
  * Created at: January 20th 2024
  * -----
- * Last Modified: March 13th 2024
+ * Last Modified: April 3rd 2024
  * Modified By: handrianalandi (handrian.alandi@gdplabs.id)
  * -----
  * Reviewers:
- *   
+ *
  * ---
  * References:
  *   NONE
@@ -32,6 +32,6 @@ export const USER_DATA_TOKEN =
 // 5. Account Savings Balance >= 30000000
 export const DVR_TOKEN =
   'eyJ0eXAiOiJKV1QiLCJqa3UiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZ2wtemtQYXNzL3prcGFzcy1zZGsvbWFpbi9kb2NzL3prcGFzcy9zYW1wbGUtandrcy92ZXJpZmllci1rZXkuanNvbiIsImtpZCI6ImstMSIsImFsZyI6IkVTMjU2In0.eyJkYXRhIjp7Inprdm0iOiJyMCIsImR2cl90aXRsZSI6Ik15IERWUiIsImR2cl9pZCI6IjEyMzQ1Njc4IiwicXVlcnlfZW5naW5lX3ZlciI6IjAuMy4wLXJjLjEiLCJxdWVyeV9tZXRob2RfdmVyIjoiNGFlZGY2NGE3YzRlMzcxMzUyNzRiNzYyNzRkMTRhMTkyZTNhZmJlNGViYTEyZjNjOTA0MmI1ZTc5ZjJkNTQiLCJxdWVyeSI6IntcImFuZFwiOlt7XCI9PVwiOltcImJjYURvY0lEXCIsXCJET0M4OTc5MjNDUFwiXX0se1wifj09XCI6W1wicGVyc29uYWxJbmZvLmZpcnN0TmFtZVwiLFwiRGV3aVwiXX0se1wifj09XCI6W1wicGVyc29uYWxJbmZvLmxhc3ROYW1lXCIsXCJQdXRyaVwiXX0se1wifj09XCI6W1wicGVyc29uYWxJbmZvLmRyaXZlckxpY2Vuc2VOdW1iZXJcIixcIkRMMTIzNDU2Nzg5XCJdfSx7XCI-PVwiOltcImZpbmFuY2lhbEluZm8uY3JlZGl0UmF0aW5ncy5wZWZpbmRvXCIsNjUwXX0se1wiPj1cIjpbXCJmaW5hbmNpYWxJbmZvLmFjY291bnRzLnNhdmluZ3MuYmFsYW5jZVwiLDMwMDAwMDAwXX1dfSIsInVzZXJfZGF0YV91cmwiOiJodHRwczovL3h5ei5jb20iLCJ1c2VyX2RhdGFfdmVyaWZ5aW5nX2tleSI6eyJLZXlzZXRFbmRwb2ludCI6eyJqa3UiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vZ2wtemtQYXNzL3prcGFzcy1zZGsvbWFpbi9kb2NzL3prcGFzcy9zYW1wbGUtandrcy9pc3N1ZXIta2V5Lmpzb24iLCJraWQiOiJrLTEifX0sImR2cl92ZXJpZnlpbmdfa2V5Ijp7IktleXNldEVuZHBvaW50Ijp7ImprdSI6Imh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS9nbC16a1Bhc3MvemtwYXNzLXNkay9tYWluL2RvY3MvemtwYXNzL3NhbXBsZS1qd2tzL3ZlcmlmaWVyLWtleS5qc29uIiwia2lkIjoiay0xIn19fX0.gWc8T2-1fomPF8OCUSzLLobkb6fgBe-7vyB5zdji0hDudkOa3UvR3hp4uPOxjBxsI_aAUYg4v06TJkVKq7um5w';
-export const ZKPASS_URL = 'https://playground-zkpass.ssi.id';
-export const ZKPASS_API_KEY = '5ecb2229-ddee-460e-b598-a0001c10fff1';
-export const ZKPASS_API_SECRET = '074a53a8-a252-45de-a9d5-0961a6362df6';
+export const ZKPASS_URL = 'https://staging-zkpass.ssi.id';
+export const ZKPASS_API_KEY = 'e7fd7ec9-33b2-4f33-a383-c2f1d151a7c2';
+export const ZKPASS_API_SECRET = '6a79ffa2-5fe8-4764-8edf-0ebc5dbcccf9';


### PR DESCRIPTION
[update zkpass client to v1.0.0-alpha.1](fix: update zkpass client to v1.0.0-alpha.1)

Please :
- Make sure to use latest `.env.example` **(wihtout `/proof` in the zkpass url)**
- Install zkpass-client-ts from staging registry
- Use staging url to generate the proof (see below for url and credentials)
```
ZKPASS_SERVICE_URL="https://staging-zkpass.ssi.id/"
ZKPASS_API_KEY="e7fd7ec9-33b2-4f33-a383-c2f1d151a7c2"
ZKPASS_SECRET_API_KEY="6a79ffa2-5fe8-4764-8edf-0ebc5dbcccf9"
```