### PR TITLE
[Draft]Reduce Duplication Effort in zkpass-sdk

### DIFF
--- a/rust/submodules.sh
+++ b/rust/submodules.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Variables
+REPO_ZKPASS_URL="https://github.com/GDP-ADMIN/zkPass.git"
+TEMP_REPO_ZKPASS_DIR="tmp/zkpass"
+DIRS_TO_COPY=("zkpass-client" "zkpass-demo/src" "zkpass-demo/tests" "zkpass-demo/Cargo.toml" "zkpass-core" "zkpass-query/types")  # The directories and files to copy
+
+# Clone repo A to a temporary directory
+git clone "$REPO_ZKPASS_URL" "$TEMP_REPO_ZKPASS_DIR"
+
+# Check if the directories or files to copy exist in the temporary cloned repo
+for DIR in "${DIRS_TO_COPY[@]}"; do
+  if [ ! -e "$TEMP_REPO_ZKPASS_DIR/$DIR" ]; then
+    echo "$DIR does not exist in the temporary cloned repo."
+    exit 1
+  fi
+done
+
+# Create necessary directories in the current repo
+for DIR in "${DIRS_TO_COPY[@]}"; do
+  DEST_DIR=$(dirname "$DIR")
+  if [ "$DEST_DIR" != "." ]; then
+    if [ ! -e "$DEST_DIR" ]; then
+        mkdir -p "$DEST_DIR"
+    fi
+  else
+    rm -rf "$DIR"
+  fi
+done
+
+# Copy each directory or file from the temporary cloned repo to the current repo
+for DIR in "${DIRS_TO_COPY[@]}"; do
+  if [ -d "$TEMP_REPO_ZKPASS_DIR/$DIR" ]; then
+    # If it's a directory, copy contents
+    cp -r "$TEMP_REPO_ZKPASS_DIR/$DIR/." "$DIR"
+  else
+    # If it's a file, copy the file
+    cp "$TEMP_REPO_ZKPASS_DIR/$DIR" "$DIR"
+  fi
+done
+
+# Clean up the temporary directory
+rm -rf "$TEMP_REPO_ZKPASS_DIR"
+rm -rf "tmp"  # Remove the tmp directory
+
+echo "Submodules have been successfully copied."


### PR DESCRIPTION
[Draft]
Asana : https://app.asana.com/0/1206389362636911/1207242505646832/f

Still want to explore Git Submodules and Git Subtree

### Changes
1. add Automatic Script submodules.sh to copy related folder needed from zkpass repository into zkpass-sdk

### Issues
Other alternatives : git submodules or git subtree. 

**Using Git Submodules**
Git submodules are used to include external repositories within a subdirectory of your own repository. However, submodules include the entire repository rather than specific directories. To include specific directories, you might need to use sparse checkout with submodules, but this is more complex and not always recommended for this use case.

**Using Git Subtree**
The git subtree command doesn't directly support extracting only specific folders from a remote repository. It includes the entire repository history of the target subtree, but you can selectively use specific directories or files within your repository after pulling the subtree. However, if you only want to include specific directories without pulling the entire repository, you'd need to handle this with scripting or other tools.

For your specific need to only include certain folders from a remote repository and keep them up-to-date, the automation script method might still be the best solution. If you prefer using Git for this, you can try using sparse checkout with submodules or create a custom script that mimics subtree functionality.

---

### Testing scenario
1. Automatic Scripting 
`. /rust/submodules.sh`

### Expected Result / Output
- No need to copy manually related folder needed from zkpass repository into zkpass-sdk