### PR TITLE
handle single user data bug

### DIFF
--- a/typescript/node-js/cli/src/MyVerifier.ts
+++ b/typescript/node-js/cli/src/MyVerifier.ts
@@ -90,14 +90,23 @@ export class MyVerifier extends Verifier {
 
     const queryObj = JSON.parse(query);
     const userDataRequests: UserDataRequests = {};
-    dataTags.forEach((tag) => {
-      userDataRequests[tag] = {
+    if (dataTags.length === 1) {
+      userDataRequests[""] = {
         user_data_url: USER_DATA_URL,
         user_data_verifying_key: {
           KeysetEndpoint: issuerPubkey,
         },
       };
-    });
+    } else {
+      dataTags.forEach((tag) => {
+        userDataRequests[tag] = {
+          user_data_url: USER_DATA_URL,
+          user_data_verifying_key: {
+            KeysetEndpoint: issuerPubkey,
+          },
+        };
+      });
+    }
 
     const dvrData: DvrData = {
       dvr_title: DVR_TITLE,

--- a/typescript/node-js/cli/src/MyVerifier.ts
+++ b/typescript/node-js/cli/src/MyVerifier.ts
@@ -90,23 +90,15 @@ export class MyVerifier extends Verifier {
 
     const queryObj = JSON.parse(query);
     const userDataRequests: UserDataRequests = {};
-    if (dataTags.length === 1) {
-      userDataRequests[""] = {
+    dataTags.forEach((tag) => {
+      const key = dataTags.length === 1 ? "" : tag;
+      userDataRequests[key] = {
         user_data_url: USER_DATA_URL,
         user_data_verifying_key: {
           KeysetEndpoint: issuerPubkey,
         },
       };
-    } else {
-      dataTags.forEach((tag) => {
-        userDataRequests[tag] = {
-          user_data_url: USER_DATA_URL,
-          user_data_verifying_key: {
-            KeysetEndpoint: issuerPubkey,
-          },
-        };
-      });
-    }
+    });
 
     const dvrData: DvrData = {
       dvr_title: DVR_TITLE,


### PR DESCRIPTION
## Description
- known bug, when running single user data on cli folder, it was broken because user data requests on dvr is not handled well

## How to test
### Cli
1. go to folder `typescript/node-js/cli`
2. run `npm i`
3. run all demo (`npm run demo-multi`, `npm run demo-basic`, etc)

### Issuer-verifier & client
1. go to folder `typescript/node-js/client` & `typescript/node-js/issuer-verifier`
2. run `npm i` on both folder
3. run `npm run dev` on both folder
4. login as any of the user ("john", "jane", etc)
5. click on `start employee onboarding (single user data)` and `start employee onboarding (multiple user data)` buttons

Scenario:
  1. john:
      - single: pass
      - multiple: pass
  2. jake: 
      - single: pass
      - multiple: not pass (mismatch kycType)
  3. jane:
      - single: not pass (high cocaine)
      - multiple: not pass (high cocaine)
  4. rob:
      - single: pass
      - multiple: not pass (mismatch dateOfBirth)
  5. kyle:
      - single: not pass (high cocaine)
      - multiple: not pass (high cocaine & mismactch kycId)